### PR TITLE
refactor: gradio中执行的js改为引用custom.js

### DIFF
--- a/ChuanhuChatbot.py
+++ b/ChuanhuChatbot.py
@@ -348,6 +348,7 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
         inputs=[current_model],
         outputs=[chatbot, status_display],
         show_progress=True,
+        _js='()=>{clearHistoryHtml();}',
     )
 
     retryBtn.click(**start_outputing_args).then(
@@ -433,15 +434,7 @@ with gr.Blocks(css=customCSS, theme=small_and_beautiful_theme) as demo:
         show_progress=True,
     )
     historyRefreshBtn.click(**refresh_history_args)
-    historyDeleteBtn.click(delete_chat_history, [current_model, historyFileSelectDropdown, user_name], [status_display, historyFileSelectDropdown, chatbot], _js='''function showConfirmationDialog(a, b, c) {
-  if (b != "") {
-    var result = confirm(deleteConfirm_msg_pref + b + deleteConfirm_msg_suff);
-    if (result) {
-        return [a, b, c];
-    }
-  }
-  return [a, "CANCELED", c];
-}''')
+    historyDeleteBtn.click(delete_chat_history, [current_model, historyFileSelectDropdown, user_name], [status_display, historyFileSelectDropdown, chatbot], _js='(a,b,c)=>{return showConfirmationDialog(a, b, c);}')
     historyFileSelectDropdown.change(**load_history_from_file_args)
     downloadFile.change(upload_chat_history, [current_model, downloadFile, user_name], [saveFileName, systemPromptTxt, chatbot])
 

--- a/assets/custom.js
+++ b/assets/custom.js
@@ -15,7 +15,6 @@ var appTitleDiv = null;
 var chatbot = null;
 var chatbotWrap = null;
 var apSwitch = null;
-var empty_botton = null;
 var messageBotDivs = null;
 var loginUserForm = null;
 var logginUser = null;
@@ -62,7 +61,6 @@ function gradioLoaded(mutations) {
             chatbot = document.querySelector('#chuanhu_chatbot');
             chatbotWrap = document.querySelector('#chuanhu_chatbot > .wrap');
             apSwitch = document.querySelector('.apSwitch input[type="checkbox"]');
-            empty_botton = document.getElementById("empty_btn")
 
             if (loginUserForm) {
                 localStorage.setItem("userLogged", true);
@@ -90,9 +88,6 @@ function gradioLoaded(mutations) {
                 }
                 setChatbotScroll();
             }
-            if (empty_botton) {
-                emptyHistory();
-            }
         }
     }
 }
@@ -109,6 +104,16 @@ function webLocale() {
         deleteConfirm_msg_pref = deleteConfirm_i18n_pref[language];
         deleteConfirm_msg_suff = deleteConfirm_i18n_suff[language];
     }
+}
+
+function showConfirmationDialog(a, file, c) {
+    if (file != "") {
+        var result = confirm(deleteConfirm_msg_pref + file + deleteConfirm_msg_suff);
+        if (result) {
+            return [a, file, c];
+        }
+    }
+    return [a, "CANCELED", c];
 }
 
 function selectHistory() {
@@ -489,11 +494,6 @@ function clearHistoryHtml() {
         chatbotWrap.removeChild(historyMessages);
         console.log("History Cleared");
     }
-}
-function emptyHistory() {
-    empty_botton.addEventListener("click", function () {
-        clearHistoryHtml();
-    });
 }
 
 // 监视页面内部 DOM 变动


### PR DESCRIPTION
改了两处：
- 清除对话历史的confirm改为customjs中的函数；
- 改了新的对话时清除仅供查看历史记录的js写法，更简洁了。

<!--
这是一个拉取请求模板。本文段处于注释中，请您先查看本注释，在您提交时该段文字将不会显示。

1. 在提交拉取请求前，您最好已经查看过 [https://github.com/GaiZhenbiao/ChuanhuChatGPT/wiki/贡献指南] 了解了我们的大致要求；
2. 如果您的这一个pr包含多个不同的功能添加或问题修复，请务必将您的提交拆分为多个不同的原子化的commit，甚至您可以在不同的分支中提交多个pull request；
3. 不过，就算您的提交完全不合规范也没有关系，您可以直接提交，我们会进行审查。总之我们欢迎您做出贡献！

另外，我们将使用 Copilot4PR 自动补充撰写您的 pull request，请暂时不要删改 Copilot 撰写的内容。
-->

## 作者自述
### 描述
描述您的 pull request 所做的更改。
另外请附上相关程序运行时的截图（before & after），以直观地展现您的更改达成的效果。

### 相关问题
（如有）请列出与此拉取请求相关的issue。

### 补充信息
（如有）请提供任何其他信息或说明，有助于其他贡献者理解您的更改。
如果您提交的是 draft pull request，也请在这里写明开发进度。

<!-- 写明开发进度的例子： WIP EXAMPLE:

#### 开发进度
- [x] 已经做好的事情1
- [ ] 还要干的事情1
- [ ] 还要干的事情2

-->


<!-- ############ Copilot for pull request ############
     不要删除下面的内容！ DO NOT DELETE THE CONTENT BELOW! 
-->
## Copilot4PR
copilot:all